### PR TITLE
Add support for native image cfg files and handle jump tables

### DIFF
--- a/lib/cfg2asm/cfg/cfg_parser.rb
+++ b/lib/cfg2asm/cfg/cfg_parser.rb
@@ -19,6 +19,32 @@ module Cfg2asm
         @state = :any
         @cfg_name = nil
       end
+      
+      def print_summar_of_content
+        state = :any
+        loop do
+          line = @reader.readline("\n")
+          case line
+          when "begin_compilation\n"
+            state = :some
+            puts "Compilation:"
+          when "end_compilation\n"
+            state = :any
+          when "begin_cfg\n"
+            state = :some
+            puts "Config:"
+          when "end_cfg\n"
+            state = :any
+          when /  name "(.*)"\n/
+            if state == :some
+              puts "name: #{Regexp.last_match(1)}"
+              state = :any
+            end
+          else
+            next
+          end
+        end
+      end
 
       def skip_over_cfg(name)
         loop do

--- a/lib/cfg2asm/cfg/cfg_parser.rb
+++ b/lib/cfg2asm/cfg/cfg_parser.rb
@@ -46,7 +46,7 @@ module Cfg2asm
         end
       end
 
-      def skip_over_cfg(name)
+      def skip_over_cfg(name1, name2)
         loop do
           line = @reader.readline("\n")
           case line
@@ -61,7 +61,7 @@ module Cfg2asm
             raise unless @state == :cfg
 
             @state = :any
-            break if @cfg_name == name
+            break if @cfg_name == name1 || @cfg_name == name2
           else
             next
           end

--- a/lib/cfg2asm/cfg/disassembler.rb
+++ b/lib/cfg2asm/cfg/disassembler.rb
@@ -13,9 +13,20 @@ module Cfg2asm
         nmethod.jump_tables.each do |t|
           # t.:position, :entry_format, :low, :high
           (t.low..t.high).each do |i|
-            (0...t.entry_format).each do |j|
-               # NOOP for x86
-              code.setbyte(t.position + (t.entry_format * i) + j, 0x90)
+            if t.entry_format == 4
+              code.setbyte(t.position + (t.entry_format * i) + 0, 0x0F)
+              code.setbyte(t.position + (t.entry_format * i) + 1, 0x1F)
+              code.setbyte(t.position + (t.entry_format * i) + 2, 0x40)
+              code.setbyte(t.position + (t.entry_format * i) + 3, 0x00)
+            elsif t.entry_format == 8
+              code.setbyte(t.position + (t.entry_format * i) + 0, 0x0F)
+              code.setbyte(t.position + (t.entry_format * i) + 1, 0x1F)
+              code.setbyte(t.position + (t.entry_format * i) + 2, 0x84)
+              code.setbyte(t.position + (t.entry_format * i) + 3, 0x00)
+              code.setbyte(t.position + (t.entry_format * i) + 4, 0x00)
+              code.setbyte(t.position + (t.entry_format * i) + 5, 0x00)
+              code.setbyte(t.position + (t.entry_format * i) + 6, 0x00)
+              code.setbyte(t.position + (t.entry_format * i) + 7, 0x00)
             end
           end
         end

--- a/lib/cfg2asm/commands.rb
+++ b/lib/cfg2asm/commands.rb
@@ -55,7 +55,7 @@ module Cfg2asm
 
         files.each_with_index do |file, n|
           parser = Cfg2asm::CFG::CFGParser.new(@out, file)
-          parser.skip_over_cfg 'After code installation'
+          parser.skip_over_cfg('After code installation', 'After code generation')
           nmethod = parser.read_nmethod
 
           disassembler = Cfg2asm::CFG::Disassembler.new(@out)

--- a/lib/cfg2asm/commands.rb
+++ b/lib/cfg2asm/commands.rb
@@ -7,6 +7,27 @@ module Cfg2asm
     def initialize(out)
       @out = out
     end
+    
+    def get_files_and_comments_flag(args)
+      comments = true
+      files = []
+
+      until args.empty?
+        arg = args.shift
+        if arg.start_with?('-')
+          case arg
+          when '--no-comments'
+            comments = false
+          else
+            raise ArgumentError, "unknown option #{arg}"
+          end
+        else
+          files.push arg
+        end
+      end
+      
+      [files, comments]
+    end
 
     def cfg2asm(*args)
       case args.first
@@ -21,23 +42,16 @@ module Cfg2asm
       when 'version', '-v', '-version', '--version'
         args = args.drop(1)
         version(*args)
-      else
-        comments = true
-        files = []
+      when 'summary'
+        args.shift
+        files, comments = get_files_and_comments_flag(args)
 
-        until args.empty?
-          arg = args.shift
-          if arg.start_with?('-')
-            case arg
-            when '--no-comments'
-              comments = false
-            else
-              raise ArgumentError, "unknown option #{arg}"
-            end
-          else
-            files.push arg
-          end
+        files.each_with_index do |file, n|
+          parser = Cfg2asm::CFG::CFGParser.new(@out, file)
+          parser.print_summar_of_content
         end
+      else
+        files, comments = get_files_and_comments_flag(args)
 
         files.each_with_index do |file, n|
           parser = Cfg2asm::CFG::CFGParser.new(@out, file)


### PR DESCRIPTION
In native image, the code section is named differently, so this PR skips now through the file until it fines one or the other cfg section.

It also adds a `summary` command to get an idea of what's in the file.

And finally, the jump tables are encoded directly in the instruction stream.
So, that breaks dissemblers, which will simply stop or misinterpret the found bytes.

To avoid this, the jump table entries are now replaced by nop instructions.

Note: this is limited to x86, and no specs were added.