### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: if [[ $(uname) == "Darwin" ]]; then brew install capstone; else sudo apt-get install libcapstone3; fi
+    - run: if [[ $(uname) == "Darwin" ]]; then brew install capstone; else sudo apt-get install libcapstone4; fi
     - run: bundle exec rake specs
   specs-no-dependencies:
     strategy:

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -7,14 +7,14 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - run: bundle exec rake rubocop
   specs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'truffleruby']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.1']
+        ruby: ['3.2']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Actions changed the _ubuntu-latest_ target to Ubuntu 22.04. Our existing CI config assumes Ubuntu 20.04 and, as such, CI is failing on package installations. I've also added support for Ruby 3.2 and TruffleRuby to CI.